### PR TITLE
Add Iteration Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [PyMuPDF4LLM](https://pymupdf.readthedocs.io/en/latest/pymupdf4llm/) - Aimed to make it easier to extract PDF content in the format you need for LLM & RAG environments. It supports Markdown extraction as well as LlamaIndex document output.
 - [CatchTheTornado/pdf-extract-api](https://github.com/CatchTheTornado/pdf-extract-api) - Document (PDF) extraction and parse API using state of the art modern OCRs + Ollama supported models. Anonymize documents. Remove PII. Convert any document or picture to structured JSON or Markdown.
 - [climatepolicyradar/navigator-document-parser](https://github.com/climatepolicyradar/navigator-document-parser) - Parsing PDFs and websites containing laws and policies.
+- [Iteration Layer](https://iterationlayer.com) - Document extraction API that extracts structured data from PDFs, images, DOCX, and text files using AI.
 
 
 ## Creation and production

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 - [PyMuPDF4LLM](https://pymupdf.readthedocs.io/en/latest/pymupdf4llm/) - Aimed to make it easier to extract PDF content in the format you need for LLM & RAG environments. It supports Markdown extraction as well as LlamaIndex document output.
 - [CatchTheTornado/pdf-extract-api](https://github.com/CatchTheTornado/pdf-extract-api) - Document (PDF) extraction and parse API using state of the art modern OCRs + Ollama supported models. Anonymize documents. Remove PII. Convert any document or picture to structured JSON or Markdown.
 - [climatepolicyradar/navigator-document-parser](https://github.com/climatepolicyradar/navigator-document-parser) - Parsing PDFs and websites containing laws and policies.
-- [Iteration Layer](https://iterationlayer.com) - Document extraction API that extracts structured data from PDFs, images, DOCX, and text files using AI.
+- [Iteration Layer](https://iterationlayer.com) - An AI-powered API that extracts structured data from PDFs, images, DOCX, and text files.
 
 
 ## Creation and production


### PR DESCRIPTION
Adds [Iteration Layer](https://iterationlayer.com) to the Parsers, OCR and extraction section.

Closes https://github.com/OneOffTech/awesome-pdf/issues/12

## What it does
Iteration Layer is a document extraction API that uses AI to extract structured data from PDFs, images (PNG, JPG, WebP), DOCX, and text files. You define a schema with fields and receive structured JSON output.

## Why it fits
The Parsers, OCR and extraction section lists tools like Reducto (Document Ingestion API) and pdf-extract-api. Iteration Layer serves the same purpose — an API for AI-powered structured extraction from PDFs and other documents.

- **Website:** https://iterationlayer.com
- **Docs:** https://iterationlayer.com/docs
- **Changelog:** https://iterationlayer.com/changelog