### PR TITLE
Add BayMaxHome PDF Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - [WeasyPrint](https://weasyprint.org/) - Generate PDF using html and CSS.
 - [qpdf/qpdf](https://github.com/qpdf/qpdf) - A content-preserving PDF document transformer.
 - [Stirling-Tools/Stirling-PDF](https://github.com/Stirling-Tools/Stirling-PDF) - A locally hosted web-based PDF manipulation tool using Docker that supports splitting, merging, converting, reorganizing, compressing, and more.
+- [BayMaxHome PDF Tools](https://liaopengdong.github.io/pdf-tools/) - Free browser-based PDF tools for merging, splitting, rotating, converting, watermarking, numbering, and editing PDF files.
 - [unjs/unpdf](https://github.com/unjs/unpdf) - Utilities to work with PDFs in Node.js, browser and workers.
 - [PdfRest](https://pdfrest.com/) - PDF Api to create, shrink and compress.
 - [Gotenberg](https://gotenberg.dev/) - A Docker-powered stateless API for creating PDF files from templates in various formats, e.g., html, markdown, word, excel.


### PR DESCRIPTION
Adds BayMaxHome PDF Tools, a free browser-based PDF utility site for common tasks such as merging, splitting, rotating, converting, watermarking, numbering, and editing PDF files.