### PR TITLE
Add PDF Dark to Readers and viewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [mozilla/pdf.js](https://github.com/mozilla/pdf.js) - PDF Reader in JavaScript.
 - [agentcooper/react-pdf-highlighter](https://github.com/agentcooper/react-pdf-highlighter) - Set of React components for PDF annotation.
 - [Sioyek](https://sioyek.info/) - PDF viewer with a focus on technical books and research papers (desktop app).
+- [PDF Dark](https://pdfdark.org) - Convert any PDF to dark mode, fully in the browser. Open-source and client-side only — no upload required.
 
 
 ## Validation and compliance


### PR DESCRIPTION
Adds [PDF Dark](https://pdfdark.org) to the Readers and viewers section.

Closes https://github.com/OneOffTech/awesome-pdf/issues/18

## What it does
PDF Dark is a free, open-source web app that converts any PDF to dark mode entirely in the browser. It uses PDF.js for rendering and applies color inversion + theme transforms client-side, so files are never uploaded — making it usable for sensitive or confidential documents too. Supports four themes (true dark, sepia, blue-tint, high-contrast) and preserves embedded images.

## Why it fits
The Readers and viewers section already lists tools like [mozilla/pdf.js](https://github.com/mozilla/pdf.js) and [Sioyek](https://sioyek.info/). PDF Dark serves the same purpose — a PDF reader/viewer — with a complementary niche (eye-friendly dark mode for night reading) and a notable privacy property (zero upload, fully client-side).

- **Website:** https://pdfdark.org
- **Repo:** https://github.com/1436941541/pdf-dark
- **License:** MIT