### PR TITLE
Add toolkit.bot/pdf2epub — PDF to accessible EPUB3 converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - [Vexlio](https://vexlio.com/) - Tool to create diagrams and export in SVG or PDF.
 - [renamed.to](https://www.renamed.to) - AI-powered tool that renames files based on the content, accessible as a web app, command line, and for integration within your application.
 - [BentoPDF](https://www.bentopdf.com/) - A privacy-first, self-hostable PDF toolkit that manipulates, edits, merges and processes files entirely in the browser, with no server-side processing.
+- [PDF 2 EPUB](https://github.com/bernardotorres/pdf2epub) - Converts PDF to reflowable EPUB 3 compliant with EPUB Accessibility 1.1 and WCAG 2.2 AA.
 
 ## Readers and viewers
 


### PR DESCRIPTION
Adds [toolkit.bot/pdf2epub](https://toolkit.bot/pdf2epub) to the Creation and production section.

Converts PDF to reflowable EPUB3 with EPUB Accessibility 1.1 and WCAG 2.2 AA compliance. Free web service with REST API. Source: https://github.com/bernardotorres/pdf2epub